### PR TITLE
fix: add missing callback invocation in postAceInit hook

### DIFF
--- a/static/js/disable.js
+++ b/static/js/disable.js
@@ -9,4 +9,5 @@ exports.postAceInit = (hookName, args, cb) => {
     #myusernameedit{background:lightgrey !important;}
     #myusernameedit:hover{background:lightgrey !important;color:#333 !important}
   </style>`);
+  return cb();
 };


### PR DESCRIPTION
Found during a systematic audit of all Etherpad plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)