### PR TITLE
docs: use a human-readable README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Publish Status](https://github.com/ether/ep_disable_change_author_name/workflows/Node.js%20Package/badge.svg) [![Backend Tests Status](https://github.com/ether/ep_disable_change_author_name/actions/workflows/test-and-release.yml/badge.svg)](https://github.com/ether/ep_disable_change_author_name/actions/workflows/test-and-release.yml)
 
-# ep_disable_change_author_name
+# Disable Author Name Changes in Etherpad
 
 TODO: Describe the plugin.
 


### PR DESCRIPTION
Replace the placeholder `ep_disable_change_author_name` heading in README.md with "Disable Author Name Changes in Etherpad" so browsers of the plugin list on GitHub / npm can see what the plugin does at a glance.