### PR TITLE
chore: declare @feature:username disable + use disables-aware test runner

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -69,4 +69,10 @@ jobs:
           done
           cd src
           pnpm exec playwright install chromium --with-deps
-          pnpm run test-ui --project=chromium
+          # Use the declared-disables helper instead of plain test-ui:
+          # ep.json declares `disables: ["@feature:username"]`, so the
+          # helper runs two passes — regression (everything not tagged
+          # @feature:username must pass) + honesty (every test tagged
+          # @feature:username must FAIL because the plugin disables
+          # username editing). See doc/PLUGIN_FEATURE_DISABLES.md.
+          ../bin/run-frontend-tests-with-disables.sh -- --project=chromium

--- a/ep.json
+++ b/ep.json
@@ -1,4 +1,5 @@
 {
+  "disables": ["@feature:username"],
   "parts":[
     {
       "name": "disableNameInputbox",


### PR DESCRIPTION
Mirrors [ep_disable_chat#75](https://github.com/ether/ep_disable_chat/pull/75) (already merged, shipped v0.0.40) for the username feature.

## Changes
- `ep.json` declares `"disables": ["@feature:username"]` so etherpad.org/plugins and the Etherpad /admin UI surface what this plugin removes before install.
- `.github/workflows/frontend-tests.yml` swaps `pnpm run test-ui` for `../bin/run-frontend-tests-with-disables.sh -- --project=chromium`. The helper:
  - runs every spec NOT tagged `@feature:username` (regression — must pass)
  - runs every spec tagged `@feature:username` and expects them to FAIL fast on the first failure (honesty — proves the plugin actually disables username editing)

See [the contract proposal](https://github.com/ether/etherpad/pull/7648) and `doc/PLUGIN_FEATURE_DISABLES.md` for design details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)